### PR TITLE
解决 wx.setNavigationBarColor 缺少 backgroundColor 参数报错的问题

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,6 +72,7 @@ Component({
       if (this.data.textStyle === 'black') {
         wx.setNavigationBarColor({
           frontColor: '#000000',
+          backgroundColor: this.data.bgStyle,
         })
         this.setData({
           navIconUrl: './images/nav_icon_black.png',
@@ -81,6 +82,7 @@ Component({
       } else {
         wx.setNavigationBarColor({
           frontColor: '#ffffff',
+          backgroundColor: this.data.bgStyle,
         })
         this.setData({
           navIconUrl: './images/nav_icon_white.png',


### PR DESCRIPTION
传入 text-style 参数时会调用 wx.setNavigationBarColor, 缺少了 backgroundColor 参数，控制台报错了。我把这个参数设置为 bgStyle 了